### PR TITLE
Fix reported version number for conda

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
@@ -19,6 +19,7 @@ requirements:
     - pip
     - python >=3.6
     - setuptools >=42
+    - setuptools_scm >=3.4
     - wheel
   run:
     - python >=3.6


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] ~~Reset the build number to `0` (if the version changed)~~
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

---

`asf_search` when installed via conda-forge reports a version number of `0.0.0`:
```shell
$ conda create -n foo python asf_search
$ conda activate foo
$ python -c 'import asf_search; print(asf_search.__version__)'
0.0.0
```

However a `pip` install works just fine:
```shell
$ conda create -n bar python
$ conda activate bar
$ python -m pip install asf_search
$ python -c 'import asf_search; print(asf_search.__version__)'
5.0.1
```

This is because conda uses the source tarball to install the package, but is missing the `setuptools_scm` build dependency which handles the version info:
https://github.com/asfadmin/Discovery-asf_search/blob/master/pyproject.toml#L5

This adds the missing build dependency and bumps the build number for conda-forge fixing this issue. 