### PR TITLE
Add bottom pin for dateparser

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
@@ -29,7 +29,7 @@ requirements:
     - pytz
     - importlib_metadata
     - numpy
-    - dateparser
+    - dateparser >=1.1.1
 
 test:
   imports:


### PR DESCRIPTION
As described in asfadmin/Discovery-asf_search#124, when installing `asf_search>5.0.0`, conda is pulling in:
* `dateparser==1.0.0`
* `regex==2022.7.9`

However, `dateparser` has a known bug with with `regex` and only works with[`regex !=2019.02.19,!=2021.8.27,<2022.3.15`](https://github.com/scrapinghub/dateparser/blob/master/setup.py#L30) as pinned in the current `dateparser==1.1.1`.

In our recipe, `dateparser` is *unpinned* and so *should be pulling the latest version* (and I confirmed there's no other dateparser pinning in the entire dependency tree). In fact, `mamba` and `pip` do the right thing here and pull in `dateparser==1.1.1`  so this is *a super weird* issue with `conda` itself. 

Here, we are forcing conda to do the right thing by pinning `dateparser>=1.1.1`.

---

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] ~~Reset the build number to `0` (if the version changed)~~
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
