### PR TITLE
add output for asf_search-base

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @Cameronsplaze @glshort @jhkennedy @williamh890
+* @Cameronsplaze @SpicyGarlicAlbacoreRoll @glshort @jhkennedy @williamh890

--- a/README.md
+++ b/README.md
@@ -3,11 +3,33 @@ About asf_search-feedstock
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/asf_search-feedstock/blob/main/LICENSE.txt)
 
+
+About asf_search
+----------------
+
 Home: https://github.com/asfadmin/Discovery-asf_search
 
 Package license: BSD-3-Clause
 
 Summary: Python wrapper for ASF's SearchAPI
+
+About asf_search-base
+---------------------
+
+
+
+Package license: 
+
+asf_search without any optional extra packages
+
+About asf_search
+----------------
+
+
+
+Package license: 
+
+asf_search with all optional extra packages
 
 Current build status
 ====================
@@ -145,6 +167,7 @@ Feedstock Maintainers
 =====================
 
 * [@Cameronsplaze](https://github.com/Cameronsplaze/)
+* [@SpicyGarlicAlbacoreRoll](https://github.com/SpicyGarlicAlbacoreRoll/)
 * [@glshort](https://github.com/glshort/)
 * [@jhkennedy](https://github.com/jhkennedy/)
 * [@williamh890](https://github.com/williamh890/)

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Current release info
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-asf_search-green.svg)](https://anaconda.org/conda-forge/asf_search) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/asf_search.svg)](https://anaconda.org/conda-forge/asf_search) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/asf_search.svg)](https://anaconda.org/conda-forge/asf_search) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/asf_search.svg)](https://anaconda.org/conda-forge/asf_search) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-asf_search--base-green.svg)](https://anaconda.org/conda-forge/asf_search-base) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/asf_search-base.svg)](https://anaconda.org/conda-forge/asf_search-base) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/asf_search-base.svg)](https://anaconda.org/conda-forge/asf_search-base) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/asf_search-base.svg)](https://anaconda.org/conda-forge/asf_search-base) |
 
 Installing asf_search
 =====================
@@ -39,16 +40,16 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `asf_search` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `asf_search, asf_search-base` can be installed with `conda`:
 
 ```
-conda install asf_search
+conda install asf_search asf_search-base
 ```
 
 or with `mamba`:
 
 ```
-mamba install asf_search
+mamba install asf_search asf_search-base
 ```
 
 It is possible to list all of the versions of `asf_search` available on your platform with `conda`:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ outputs:
   - name: asf_search-base
     build:
       noarch: python
-    script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+      script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
     requirements:
       host:
         - python >=3.8

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,6 +13,14 @@ build:
   noarch: python
   number: 1
 
+# This *really* shouldn't be necessary
+requirements:
+  host:
+    - python >=3.8
+    - pip
+  run:
+    - python >=3.8
+
 outputs:
   - name: asf_search-base
     about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,6 @@ source:
   sha256: 8670432a95959af4a98d6cbeb1f016e47614e280685f5648293a4f9161b795e2
 
 build:
-  noarch: python
   number: 1
 
 outputs:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,8 @@ build:
   noarch: python
   number: 1
 
-# This *really* shouldn't be necessary
+# This *really* shouldn't be necessary; see flailing here:
+# https://github.com/conda-forge/asf_search-feedstock/pull/57
 requirements:
   host:
     - python >=3.8

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 {% set version = "7.0.1" %}
 
 package:
-  name: {{ name|lower }}
+  name: {{ name|lower }}-meta
   version: {{ version }}
 
 source:
@@ -14,6 +14,8 @@ build:
 
 outputs:
   - name: asf_search-base
+    about:
+      description: asf_search without any optional extra packages
     build:
       noarch: python
       script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
@@ -44,6 +46,8 @@ outputs:
         - python -c 'from asf_search.download import download; assert download.RemoteZip is None'
 
   - name: asf_search
+    about:
+      description: asf_search with all optional extra packages
     build:
       noarch: python
     requirements:
@@ -67,6 +71,7 @@ about:
   summary: Python wrapper for ASF's SearchAPI
 
 extra:
+  feedstock-name: asf_search
   recipe-maintainers:
     - jhkennedy
     - glshort

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,35 +11,52 @@ source:
 
 build:
   noarch: python
-  number: 0
-  script: {{ PYTHON }} -m pip install . -vv
+  number: 1
 
-requirements:
-  host:
-    - pip
-    - python >=3.6
-    - setuptools >=42
-    - setuptools_scm >=3.4
-    - wheel
-  run:
-    - python >=3.6
-    - requests
-    - shapely
-    - python-dateutil
-    - pytz
-    - importlib_metadata
-    - numpy
-    - dateparser >=1.1.1
-    - remotezip >=0.10.0
-    - tenacity ==8.2.2
+outputs:
+  - name: asf_search-base
+    noarch: python
+    script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+    requirements:
+      host:
+        - python >=3.8
+        - pip
+        - setuptools >=42
+        - setuptools_scm >=3.4
+        - wheel
+      run:
+        - python >=3.8
+        - requests
+        - shapely
+        - python-dateutil
+        - pytz
+        - importlib_metadata
+        - numpy
+        - dateparser
+        - tenacity ==8.2.2
+    test:
+      imports:
+        - asf_search
+      requires:
+        - pip
+      commands:
+        - pip check
+        - python -c 'from asf_search.download import download; assert download.RemoteZip is None'
 
-test:
-  imports:
-    - asf_search
-  requires:
-    - pip
-  commands:
-    - pip check
+  - name: asf_search
+    requirements:
+      host:
+        - python >=3.8
+      run:
+        - python >=3.8
+        - remotezip >=0.10.0
+        - {{ pin_subpackage('asf_search-base', max_pin="x.x.x") }}
+    test:
+      imports:
+        - asf_search
+      commands:
+        - python -c 'from asf_search.download import download; assert download.RemoteZip is not None'
+
 about:
   home: https://github.com/asfadmin/Discovery-asf_search
   license: BSD-3-Clause

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -73,3 +73,4 @@ extra:
     - glshort
     - Cameronsplaze
     - williamh890
+    - SpicyGarlicAlbacoreRoll

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,7 @@ source:
   sha256: 8670432a95959af4a98d6cbeb1f016e47614e280685f5648293a4f9161b795e2
 
 build:
+  noarch: python
   number: 1
 
 outputs:
@@ -18,7 +19,7 @@ outputs:
       description: asf_search without any optional extra packages
     build:
       noarch: python
-      script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+      script: "{{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation"
     requirements:
       host:
         - python >=3.8
@@ -43,7 +44,7 @@ outputs:
         - pip
       commands:
         - pip check
-        - python -c 'from asf_search.download import download; assert download.RemoteZip is None'
+        - "python -c 'from asf_search.download import download; assert download.RemoteZip is None'"
 
   - name: asf_search
     about:
@@ -61,7 +62,7 @@ outputs:
       imports:
         - asf_search
       commands:
-        - python -c 'from asf_search.download import download; assert download.RemoteZip is not None'
+        - "python -c 'from asf_search.download import download; assert download.RemoteZip is not None'"
 
 about:
   home: https://github.com/asfadmin/Discovery-asf_search

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,8 @@ build:
 
 outputs:
   - name: asf_search-base
-    noarch: python
+    build:
+      noarch: python
     script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
     requirements:
       host:
@@ -44,6 +45,8 @@ outputs:
         - python -c 'from asf_search.download import download; assert download.RemoteZip is None'
 
   - name: asf_search
+    build:
+      noarch: python
     requirements:
       host:
         - python >=3.8


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] ~~Reset the build number to `0` (if the version changed)~~
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

---

With `asf_search` v7.0.0, `remotezip` is an optional dependency. Following the common pattern (e.g., matplotlib), I've updated this recipe to provide these outputs:
* `asf_search-base` which *does not* have a dependency on `remotezip`
* `asf_search` meta-package,  which depends on `asf_search-base and  `remotezip` (batteries included)

An alternative is just to provide the `asf_search` package and *without* the `remotezip` dependency, but provide:
```yaml
  run_constrained:
    - remotezip >=0.10.0
```
so that if user's do conda install remotezip they'll get the right version. 

I think the two approaches are equally valid. In the former, users get everything ready to go and may learn about `asf_search-base` upon hitting issues with `remotezip`. In the latter users will get an error message if they try to use the `remotezip` functionality that tells them to install it.

@SpicyGarlicAlbacoreRoll, @glshort, etc, any thoughts here? 

